### PR TITLE
feat(subscription-manager): update design to support secure ssr

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ resolves a promise with your chosen selection from state when the state allows y
     * [Initialization](#initialization)
     * [Subscribing to state changes](#subscribing-to-state-changes)
     * [API](#api)
-      * [`setStore`](#setstore)
       * [`subscribe`](#subscribe)
+          * [`store` (__required__)](#store-__required__)
           * [`predicate` (__required__)](#predicate-__required__)
           * [`selector` (__required__)](#selector-__required__)
   * [Contributing](#contributing)
@@ -38,57 +38,41 @@ resolves a promise with your chosen selection from state when the state allows y
 $ npm install redux-select-when-matched --prod
 ```
 
-### Initialization
-
-Your store needs to be provided to the singleton instance
-
-```js
-import {createStore} from 'redux';
-import {setStore} from 'redux-select-when-matched';
-
-const reducer = (state, action) => {
-  // your reducer implementation here
-};
-
-const store = createStore(reducer);
-
-setStore(store);
-```
-
 ### Subscribing to state changes
 
 ```js
-import {subscribe} from 'redux-select-when-matched';
+import selectWhenMatched from 'redux-select-when-matched';
+import {createStore} from 'redux';
 import {isLoaded, getResource} from 'duck';
 
-subscribe({
-  predicate: state => isLoaded(state, 'foo-type', id),
-  selector: state => getResource(state, 'foo-type', id)
-}).then(selectedDetailsFromState => {
+const store = createStore(reducer);
+const predicate = state => isLoaded(state, 'foo-type', id);
+const selector = state => getResource(state, 'foo-type', id);
+
+selectWhenMatched(store, predicate, selector).then(selectedDetailsFromState => {
   // do what you need to with the details that are now available from state
 });
 ```
 
 ### API
 
-#### `setStore`
-
-accepts your [`store`](https://redux.js.org/api/createstore) instance so that
-subscriptions can be made against it.
-
 #### `subscribe`
 
-requires an object as input that provides the `predicate` and `selector` for the subscription
+requires the raw redux `store`, `predicate` and `selector` for the subscription
 
-###### `predicate` (__required__)
+##### `store` (__required__)
+
+your redux store object
+
+##### `predicate` (__required__)
 
 accepts the new state as input, allowing you to inspect and return a boolean
 informing whether or not the promise for this subscription should be resolved
- 
-###### `selector` (__required__)
+
+##### `selector` (__required__)
 
 accepted the new state as input, allowing you to select within it to return
-the subset of state that your subscriber desires 
+the subset of state that your subscriber desires
 
 ## Contributing
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export * from './subscription-manager';
+export {default} from './subscription-manager';

--- a/test/unit/canary-test.js
+++ b/test/unit/canary-test.js
@@ -1,7 +1,0 @@
-import {assert} from 'chai';
-
-suite('canary test', () => {
-  test('that mocha is wired together correctly', () => {
-    assert.isTrue(true);
-  });
-});


### PR DESCRIPTION
With the previous, stateful manager there are cases that could cause SSR to be insecure. If two
requests came in at the same time, the selector could've ended up selecting data from the wrong
store.

BREAKING CHANGE: The api is now reworked to support each subscription being it's own usage of the
library. There is no longer a stateful component in the module due to the security implications.